### PR TITLE
chore: assert action.yaml equals release-notes.yaml

### DIFF
--- a/.github/workflows/consistency.yaml
+++ b/.github/workflows/consistency.yaml
@@ -1,0 +1,13 @@
+name: consistency
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  assert-consistency:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: assert action updated
+      run: cmp -s $GITHUB_WORKSPACE/action.yaml $GITHUB_WORKSPACE/.github/workflows/release-notes.yaml

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,30 @@
+name: Release-Notes-Preview
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+    - run: |
+        git fetch --prune --unshallow
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install requests
+    - name: Post release notes
+      run: python $GITHUB_WORKSPACE/py/main.py
+      env:
+        GITHUB_USERNAME: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.RELEASE_NOTES_PREVIEW_GITHUB_TOKEN }}


### PR DESCRIPTION
action.yaml will be the public released action for GitHub Market Place.
.github/workflows/release-notes.yaml is the dev/dogfood copy.
this commit adds an action to assert both are equal, on PRs.