### PR TITLE
fix: use optional chaining so this works

### DIFF
--- a/src/commit.ts
+++ b/src/commit.ts
@@ -39,20 +39,20 @@ function processCommits(commitHeaders: string[]): ICommitData {
     const line = commitHeader.trim();
     console.log('processing line:', line);
     const words = line.split(' ');
-
+  
     if (words[1] === 'Merge') { // hack
       console.log('treating line as a merge commit, not processing it');
       continue;
     }
 
-    if (!words[1].endsWith(':')) {
+    if (!words[1]?.endsWith(':')) {
       console.log('unknown prefix', words[1], 'treating it as misc');
       processedCommits['others'].push(line);
       continue;
     }
 
     const hash = words[0];
-    const prefix = words[1].split(':')[0];
+    const prefix = words[1]?.split(':')[0];
     const rest = words.slice(2).join(' ');
 
     const lineDescription = `${rest} (${hash})`;


### PR DESCRIPTION
```
(node:2588) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'endsWith' of undefined
processing line: 
    at processCommits (/home/runner/work/_actions/snyk/release-notes-preview/v1.6.1/dist/index.js:9586:23)
    at Object.getCommits (/home/runner/work/_actions/snyk/release-notes-preview/v1.6.1/dist/index.js:9559:12)
```

This doesn't work for me. guessing it wont work for most people due to expecting words[1] will always have a value.