### PR TITLE
fix: align formatting of release notes with semantic release

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,6 +1,8 @@
 import * as config from './config';
 import { ICommitData } from './types';
 
+const listSeperator = '* ';
+
 export function previewFromCommits(commitsData: ICommitData): string {
   if (commitsData.feat.length === 0 && commitsData.fix.length === 0) {
     return '';
@@ -8,19 +10,19 @@ export function previewFromCommits(commitsData: ICommitData): string {
 
   let title = '**Expected release notes';
   if (config.GITHUB_PR_USERNAME) {
-    title +=  ` (by @${config.GITHUB_PR_USERNAME})`;
+    title += ` (by @${config.GITHUB_PR_USERNAME})`;
   }
   title += '**';
 
   let body = '';
   if (commitsData.feat.length > 0) {
-    body += '\n_features_:\n' + commitsData.feat.join('\n') + '\n';
+    body += '\n_Features_:\n' + commitsData.feat.join(listSeperator) + '\n';
   }
   if (commitsData.fix.length > 0) {
-    body += '\n_fixes_:\n' + commitsData.fix.join('\n') + '\n';
+    body += '\n_Fixes_:\n' + commitsData.fix.join(listSeperator) + '\n';
   }
   if (commitsData.others.length > 0) {
-    body += '\n_others (will not be included in Semantic-Release notes)_:\n' + commitsData.others.join('\n');
+    body += '\n_Others (will not be included in Semantic-Release notes)_:\n' + commitsData.others.join(listSeperator);
   }
 
   // TODO probably make this configurable


### PR DESCRIPTION
The default convention for semantic release is:
* Capitalized headers
* Bug Fixes before Features
* Lists of commit items

Reference: 
* Underlying tooling https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli
* Example changelog: https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog/CHANGELOG.md